### PR TITLE
Add support for loading env values

### DIFF
--- a/.env.unittest
+++ b/.env.unittest
@@ -1,0 +1,1 @@
+TEST=test

--- a/package-lock.json
+++ b/package-lock.json
@@ -759,6 +759,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/dotenv-flow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/dotenv-flow/-/dotenv-flow-3.1.0.tgz",
+      "integrity": "sha512-qaWT42KDePdAGZFryYoV7EZnuuYZAO4KPVDWUV9OBOyJx7xCgKKERtVB7jBCM2mtKVI+OMMDK2ef11PWcHJz3g==",
+      "dev": true
+    },
     "@types/graceful-fs": {
       "version": "4.1.4",
       "resolved": "https://packages.aa.com/artifactory/api/npm/npm-public/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
@@ -2030,6 +2036,19 @@
       "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
+      }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
+    "dotenv-flow": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-flow/-/dotenv-flow-3.2.0.tgz",
+      "integrity": "sha512-GEB6RrR4AbqDJvNSFrYHqZ33IKKbzkvLYiD5eo4+9aFXr4Y4G+QaFrB/fNp0y6McWBmvaPn3ZNjIufnj8irCtg==",
+      "requires": {
+        "dotenv": "^8.0.0"
       }
     },
     "duplexer3": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,11 @@
     "url": "https://github.com/AmericanAirlines/simple-env/issues"
   },
   "homepage": "https://github.com/AmericanAirlines/simple-env#readme",
-  "dependencies": {},
+  "dependencies": {
+    "dotenv-flow": "^3.2.0"
+  },
   "devDependencies": {
+    "@types/dotenv-flow": "^3.1.0",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
     "eslint": "^7.13.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ function symbolizeVars<T>(input: Record<string, string>) {
   );
 }
 
-function parseEnv(options: DotenvConfigOptions = {}) {
+function parseEnv(options: DotenvConfigOptions) {
   config(options);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { config, DotenvConfigOptions, DotenvLoadOutput } from 'dotenv-flow';
+import { config, DotenvConfigOptions } from 'dotenv-flow';
 import { EnvVarSymbols, UndefinedEnvVars } from './types/EnvVars';
 import { SymbolWithDescription } from './types/helpers';
 import { InternalOptions, Options } from './types/Options';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { config, DotenvConfigOptions, DotenvLoadOutput } from 'dotenv-flow';
 import { EnvVarSymbols, UndefinedEnvVars } from './types/EnvVars';
 import { SymbolWithDescription } from './types/helpers';
 import { InternalOptions, Options } from './types/Options';
@@ -7,6 +8,7 @@ let _symbolizedEnvVars: Record<string, SymbolWithDescription>;
 let _options: InternalOptions = {
   required: {},
   optional: {},
+  dotEnvOptions: {},
 };
 
 const createSymbol = (description: string): SymbolWithDescription => Symbol(description) as SymbolWithDescription;
@@ -33,6 +35,18 @@ function symbolizeVars<T>(input: Record<string, string>) {
   );
 }
 
+function parseEnv(options: DotenvConfigOptions = {}): any {
+  const { parsed }: DotenvLoadOutput = config(options);
+  if (parsed) {
+    const required: Record<string, string> = {};
+    Object.keys(parsed).forEach((key) => {
+      required[key] = key;
+    });
+    return required;
+  }
+  return undefined;
+}
+
 export default function setEnv<T extends UndefinedEnvVars, V extends UndefinedEnvVars>(
   options: Options<T, V>,
 ): {
@@ -42,6 +56,8 @@ export default function setEnv<T extends UndefinedEnvVars, V extends UndefinedEn
     ..._options,
     ...options,
   };
+
+  parseEnv(_options.dotEnvOptions);
 
   const symbolizedRequiredEnvVars = symbolizeVars<EnvVarSymbols<T>>(_options.required);
   _requiredEnvVars = Object.values(symbolizedRequiredEnvVars);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,16 +35,8 @@ function symbolizeVars<T>(input: Record<string, string>) {
   );
 }
 
-function parseEnv(options: DotenvConfigOptions = {}): any {
-  const { parsed }: DotenvLoadOutput = config(options);
-  if (parsed) {
-    const required: Record<string, string> = {};
-    Object.keys(parsed).forEach((key) => {
-      required[key] = key;
-    });
-    return required;
-  }
-  return undefined;
+function parseEnv(options: DotenvConfigOptions = {}) {
+  config(options);
 }
 
 export default function setEnv<T extends UndefinedEnvVars, V extends UndefinedEnvVars>(

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -99,5 +99,11 @@ describe('simple-env', () => {
       expect(Object.getOwnPropertyDescriptors(env)).not.toHaveProperty('something');
       expect(Object.getOwnPropertyDescriptors(env)).toHaveProperty('somethingElse');
     });
+
+    it('will read variable from .env file into process.env', () => {
+      const env = setEnv({ required: { test: 'TEST' }, dotEnvOptions: { node_env: 'unittest' } });
+
+      expect(process.env.TEST).toEqual(env.test);
+    });
   });
 });

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -100,7 +100,7 @@ describe('simple-env', () => {
       expect(Object.getOwnPropertyDescriptors(env)).toHaveProperty('somethingElse');
     });
 
-    it('will read variable from .env file into process.env', () => {
+    it('will read an env variable from a .env file into process.env', () => {
       const env = setEnv({ required: { test: 'TEST' }, dotEnvOptions: { node_env: 'unittest' } });
 
       expect(process.env.TEST).toEqual(env.test);

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -1,9 +1,11 @@
+import { DotenvConfigOptions } from 'dotenv-flow';
 import { DefaultEnvVars, UndefinedEnvVars } from './EnvVars';
 import { RemoveKeys } from './helpers';
 
 export interface Options<Required extends UndefinedEnvVars = DefaultEnvVars, Optional extends UndefinedEnvVars = DefaultEnvVars> {
   required?: Required;
   optional?: RemoveKeys<Optional, keyof Required>;
+  dotEnvOptions?: DotenvConfigOptions;
 }
 
 export interface InternalOptions extends Required<Options> {


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I updated [Authors.md](../Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../THIRD-PARTY-NOTICES.txt)

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->
Extends the capabilities of dotenv-flow, so the users of this package don't need to install both packages.

simple-env should play nice with `.env` files out of the box :^)

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- e.g., "Fixes #123 - A bug that crashes the app" -->
<!-- NOTE: Each bugfix needs to use the "Fixes" or "Closes" and needs to be on its own line -->
Closes [Add support for loading env values](https://github.com/AmericanAirlines/simple-env/issues/1)
