### PR TITLE
Fix typescript error for Typescript 4.2.2

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   globals: {
     'ts-jest': {
-      tsconfig: 'src/tsconfig.json',
+      tsconfig: 'tsconfig.json',
     },
   },
   moduleFileExtensions: ['js', 'json', 'ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanairlines/simple-env",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1086,6 +1086,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -1588,6 +1589,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1711,6 +1713,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -1718,7 +1721,8 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3196,7 +3200,8 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -6309,6 +6314,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1086,7 +1086,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -1589,7 +1588,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1713,7 +1711,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -1721,8 +1718,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3200,8 +3196,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -6314,7 +6309,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -6656,9 +6650,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.2",
-      "resolved": "https://packages.aa.com/artifactory/api/npm/npm-public/typescript/-/typescript-4.1.2.tgz",
-      "integrity": "sha1-Y2nvIlFv5eEDBKrlpcSGLbVTgOk=",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
+      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
       "dev": true
     },
     "undefsafe": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "jest",
     "test:coverage": "npm run test -- --coverage",
-    "build": "tsc -p src/ --pretty",
+    "build": "tsc -p tsconfig.build.json --pretty",
     "build:watch": "npm run build -- -w",
     "start": "node dist/index.js",
     "start:watch": "nodemon -w dist -e js dist/index.js",
@@ -22,7 +22,8 @@
     "lint": "eslint \"src/**/*.ts\" --max-warnings 0",
     "lint:fix": "npm run lint -- --fix",
     "checkstyle": "prettier -l \"src/**/*.ts\"",
-    "checkstyle:fix": "npm run checkstyle -- --write"
+    "checkstyle:fix": "npm run checkstyle -- --write",
+    "tsc": "tsc -p tsconfig.build.json --noEmit --incremental false"
   },
   "repository": {
     "type": "git",
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
+    "chalk": "^4.1.0",
     "eslint": "^7.13.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.22.1",
@@ -47,6 +49,6 @@
     "prettier": "^2.1.2",
     "ts-jest": "^26.4.4",
     "ts-node": "^9.0.0",
-    "typescript": "^4.1.2"
+    "typescript": "^4.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanairlines/simple-env",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "An intuitive, strongly typed, and scalable way to retrieve environment variables",
   "keywords": [
     "env",

--- a/src/test/compilation.test.ts
+++ b/src/test/compilation.test.ts
@@ -2,25 +2,42 @@ import 'jest';
 import fs from 'fs';
 import path from 'path';
 import { exec } from 'child_process';
+import chalk from 'chalk';
 
 jest.setTimeout(10000);
 
-const shouldNotCompile = (filename: string) => async () => {
+const shouldNotCompile = (filename: string, tsErrors: string[]) => async () => {
   const fixturePath = path.join(process.cwd(), 'src/test/fixtures', filename);
   expect(fs.statSync(fixturePath).isFile()).toBe(true);
 
-  const child = exec(`npx tsc --noEmit --strict --lib es2019 ${fixturePath}`);
+  await new Promise<void>((resolve, reject) => {
+    exec(`npx tsc --noEmit --strict --lib es2019 ${fixturePath}`, (err, stdout) => {
+      expect(err?.code).toBeGreaterThan(0);
+      const foundTsErrors = stdout.match(/error TS\d+:/g)?.map((found) => found.replace('error ', '').replace(':', '')) ?? [];
 
-  await new Promise<void>((resolve) => {
-    child.on('exit', (code) => {
-      expect(code).toBeGreaterThan(0);
-      resolve();
+      try {
+        expect(foundTsErrors.sort()).toEqual(tsErrors.sort());
+        resolve();
+      } catch (jestError) {
+        const error = new Error(`
+${chalk.blueBright('==== Begin Typescript Compiler Output ====================')}
+
+${stdout.trim()}
+
+${chalk.blueBright('==== End Typescript Compiler Output ======================')}
+
+`);
+
+        error.stack = jestError.stack;
+
+        reject(error);
+      }
     });
   });
 };
 
 describe('compilation errors', () => {
-  it('missing key', shouldNotCompile('missingKey.ts'));
-  it('duplicate keys', shouldNotCompile('duplicateKeys.ts'));
-  it('optional key', shouldNotCompile('optionalKey.ts'));
+  it('missing key', shouldNotCompile('missingKey.ts', ['TS2339']));
+  it('duplicate keys', shouldNotCompile('duplicateKeys.ts', ['TS2322', 'TS2322', 'TS2322', 'TS2322']));
+  it('optional key', shouldNotCompile('optionalKey.ts', ['TS2532']));
 });

--- a/src/test/fixtures/duplicateKeys.ts
+++ b/src/test/fixtures/duplicateKeys.ts
@@ -2,5 +2,15 @@ import setEnv from '../..';
 
 setEnv({
   required: { unique1: '', duplicate: '' },
+  optional: { duplicate: '' },
+});
+
+setEnv({
+  required: { unique1: '', duplicate: '' },
   optional: { unique2: '', duplicate: '' },
+});
+
+setEnv({
+  required: { duplicate1: '', duplicate2: '' },
+  optional: { duplicate1: '', duplicate2: '' },
 });

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -6,6 +6,6 @@ export interface Options<Required extends UndefinedEnvVars = DefaultEnvVars, Opt
   optional?: RemoveKeys<Optional, keyof Required>;
 }
 
-export interface InternalOptions extends Required<Options> {
+export interface InternalOptions extends Omit<Required<Options>, 'optional'> {
   optional: DefaultEnvVars;
 }

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,5 +1,7 @@
 export type RemoveKeys<Obj, Keys> = keyof Obj extends Exclude<keyof Obj, Keys>
   ? Obj
-  : Record<Exclude<keyof Obj, Keys> extends never ? '' : Exclude<keyof Obj, Keys>, string>;
+  : Exclude<keyof Obj, Keys> extends never
+  ? Record<string, never>
+  : Record<Exclude<keyof Obj, Keys>, string>;
 
 export type SymbolWithDescription = symbol & { description: string };

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "src/test"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "moduleResolution": "node",
-    "outDir": "../dist",
+    "outDir": "dist",
     "esModuleInterop": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
@@ -13,8 +13,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "declaration": true,
-    "strict": true
+    "strict": true,
+    "noEmit": true
   },
-  "include": ["./**/*.ts"],
-  "exclude": ["node_modules", "test"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Pre-Requisites

- [x] Yes, I updated [Authors.md](../Authors.md) **OR** this is not my first contribution
- [x] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [x] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../THIRD-PARTY-NOTICES.txt)

## Description of Changes

### Fixed a typescript error for Typescript version 4.2.2

It seems that we had an error in our types that was hidden by a bug in version 4.1.x, they patched it in version 4.2.x which is why we started seeing it.

### Made the compilation tests more readable when one fails and allows you to check for multiple errors in a file.

If a compilation test fails, it will now show the output from `tsc`.

<img width="500" src="https://user-images.githubusercontent.com/7807353/109596682-57d67b80-7adc-11eb-934a-b8300f473076.png" />

You can now provide multiple Typescript error codes to make sure they are the only errors present.

![image](https://user-images.githubusercontent.com/7807353/109596766-7a689480-7adc-11eb-8906-cea09c7144e4.png)

## Related Issues

Closes #24
